### PR TITLE
优化日志与限流器内存使用

### DIFF
--- a/app/middleware/rate_limiter.py
+++ b/app/middleware/rate_limiter.py
@@ -203,6 +203,17 @@ class RateLimiter:
                 "burst_size": self.burst_size,
                 "buckets": buckets_info
             }
+
+    async def shutdown(self) -> None:
+        """停止清理任务并释放资源"""
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+            self._cleanup_task = None
+        self.buckets.clear()
     
     def get_config(self) -> Dict:
         """获取限流器配置"""


### PR DESCRIPTION
## Summary
- 限制模型回复字段预览至200字符，并维持日志文件轮转为12MB/8192份
- 流式响应结束后记录完整内容并仅截断模型输出文本，同时释放缓冲防止内存泄漏
- 新增限流器清理与关闭逻辑，避免残留任务

## Testing
- `python run_tests.py quick` *(fails: TestEnvironmentVariableConfiguration::test_provider_configuration_from_env, TestProductionReadiness::test_error_response_format, TestSystemIntegration::test_full_request_lifecycle)*

------
https://chatgpt.com/codex/tasks/task_e_689b49eccbec8328a117ffd2b6846093